### PR TITLE
fix: Use reflection to check if a method actually exists

### DIFF
--- a/src/lib/isThenable.ts
+++ b/src/lib/isThenable.ts
@@ -1,11 +1,11 @@
 import isFunction from './isFunction';
 
 function hasThen(input: { then?: Function }): boolean {
-	return isFunction(input.then);
+	return Reflect.has(input, 'then') && isFunction(input.then);
 }
 
 function hasCatch(input: { catch?: Function }): boolean {
-	return isFunction(input.catch);
+	return Reflect.has(input, 'catch') && isFunction(input.catch);
 }
 
 /**

--- a/src/lib/isThenable.ts
+++ b/src/lib/isThenable.ts
@@ -1,5 +1,10 @@
 import isFunction from './isFunction';
 
+export interface Thenable {
+	then: Function;
+	catch: Function;
+}
+
 function hasThen(input: { then?: Function }): boolean {
 	return Reflect.has(input, 'then') && isFunction(input.then);
 }
@@ -12,8 +17,8 @@ function hasCatch(input: { catch?: Function }): boolean {
  * Verify if an object is a promise.
  * @param input The promise to verify
  */
-export default function isThenable(input: unknown): boolean {
-	if (!input) return false;
+export default function isThenable(input: unknown): input is Thenable {
+	if (typeof input !== 'object' || input === null) return false;
 	return (input instanceof Promise) ||
 		(input !== Promise.prototype && hasThen(input) && hasCatch(input));
 }

--- a/src/lib/isThenable.ts
+++ b/src/lib/isThenable.ts
@@ -1,5 +1,4 @@
 import isFunction from './isFunction';
-import isObject from './isObject';
 
 export interface Thenable {
 	then: Function;


### PR DESCRIPTION
Fixes the issue when evaluating `this.client.api` with the built-in eval command.