### PR TITLE
fix: Resolved bug when merging a deep object into another

### DIFF
--- a/src/lib/mergeObjects.ts
+++ b/src/lib/mergeObjects.ts
@@ -6,15 +6,17 @@ import isObject from './isObject';
  * @param objSource The object to merge
  */
 export default function mergeObjects<
-	A extends Record<string | number | symbol, unknown>,
-	B extends Record<string | number | symbol, unknown>
+	A extends Record<PropertyKey, unknown>,
+	B extends Record<PropertyKey, unknown>
 >(objTarget: A & Partial<B>, objSource: B): A & B {
 	for (const key in objSource) {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 		// @ts-ignore
-		objTarget[key] = isObject(objSource[key]) ?
-			mergeObjects(objTarget[key] as A & Partial<B>, objSource[key] as B) :
-			objSource[key];
+		objTarget[key] = typeof objTarget[key] === 'undefined' ?
+			objSource[key] :
+			isObject(objSource[key]) ?
+				mergeObjects(objTarget[key] as A & Partial<B>, objSource[key] as B) :
+				objSource[key];
 	}
 	return objTarget as A & B;
 }

--- a/src/lib/mergeObjects.ts
+++ b/src/lib/mergeObjects.ts
@@ -8,15 +8,14 @@ import isObject from './isObject';
 export default function mergeObjects<
 	A extends Record<PropertyKey, unknown>,
 	B extends Record<PropertyKey, unknown>
->(objTarget: A & Partial<B>, objSource: B): A & B {
-	for (const key in objSource) {
-		// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-		// @ts-ignore
-		objTarget[key] = typeof objTarget[key] === 'undefined' ?
-			objSource[key] :
-			isObject(objSource[key]) ?
-				mergeObjects(objTarget[key] as A & Partial<B>, objSource[key] as B) :
-				objSource[key];
+>(objTarget: A, objSource: B): A & B {
+	for (const [key, value] of Object.entries(objSource) as [keyof B, unknown][]) {
+		const targetValue = objTarget[key];
+		if (isObject(value)) {
+			Reflect.set(objTarget, key, isObject(targetValue) ? mergeObjects(targetValue, value) : value);
+		} else if (!isObject(targetValue)) {
+			Reflect.set(objTarget, key, value);
+		}
 	}
 	return objTarget as A & B;
 }

--- a/test/mergeObjects.ts
+++ b/test/mergeObjects.ts
@@ -41,3 +41,15 @@ ava('mergeObjects(deep)', (test): void => {
 	const target = { b: { i: 4 } };
 	test.deepEqual(mergeObjects(target, source), { a: 0, b: { i: 4 } });
 });
+
+ava('mergeObjects(deep-replace)', (test): void => {
+	const source = { a: { i: 4 } };
+	const target = { a: 0 };
+	test.deepEqual(mergeObjects(target, source), { a: { i: 4 } });
+});
+
+ava('mergeObjects(deep-type-mismatch)', (test): void => {
+	const source = { a: 0 };
+	const target = { a: { b: 1 } };
+	test.deepEqual(mergeObjects(target, source), { a: { b: 1 } });
+});

--- a/test/mergeObjects.ts
+++ b/test/mergeObjects.ts
@@ -35,3 +35,9 @@ ava('mergeObjects(extended)', (test): void => {
 	const target = { a: 2, i: 2 };
 	test.deepEqual(mergeObjects(target, source), { a: 0, i: 2, b: 1 });
 });
+
+ava('mergeObjects(deep)', (test): void => {
+	const source = { a: 0 };
+	const target = { b: { i: 4 } };
+	test.deepEqual(mergeObjects(target, source), { a: 0, b: { i: 4 } });
+});


### PR DESCRIPTION
Before:

```typescript
> require('@klasa/utils').mergeObjects({ id: 'hi' }, { messages: { hello: 'world' } });
TypeError: Cannot set property 'hello' of undefined
    at mergeObjects ([*]/node_modules/@klasa/utils/dist/lib/mergeObjects.js:13:24)
    at Object.mergeObjects ([*]/node_modules/@klasa/utils/dist/lib/mergeObjects.js:14:13)
```

Now:

```typescript
> require('@klasa/utils').mergeObjects({ id: 'hi' }, { messages: { hello: 'world' } });
{ id: 'hi',
  messages: { hello: 'world' } }
```
