### PR TITLE
refactor(deepclone): allow-mutating-return-type

### DIFF
--- a/src/lib/deepClone.ts
+++ b/src/lib/deepClone.ts
@@ -6,28 +6,28 @@ import { isObject } from './isObject';
  * @since 0.5.0
  * @param source The object to clone
  */
-export function deepClone<T>(source: T): T {
+export function deepClone<T, R extends T>(source: T): R {
 	// Check if it's a primitive (with exception of function and null, which is typeof object)
-	if (source === null || isPrimitive(source)) return source;
+	if (source === null || isPrimitive(source)) return source as R;
 	if (Array.isArray(source)) {
 		const output = [] as unknown as T & T extends (infer S)[] ? S[] : never;
 		for (const value of source) output.push(deepClone(value));
-		return output as unknown as T;
+		return output as unknown as R;
 	}
 	if (isObject(source)) {
 		const output = {} as Record<PropertyKey, unknown>;
 		for (const [key, value] of Object.entries(source)) output[key] = deepClone(value);
-		return output as unknown as T;
+		return output as unknown as R;
 	}
 	if (source instanceof Map) {
 		const output = new (source.constructor as MapConstructor)() as unknown as T & T extends Map<infer K, infer V> ? Map<K, V> : never;
 		for (const [key, value] of source.entries()) output.set(key, deepClone(value));
-		return output as unknown as T;
+		return output as unknown as R;
 	}
 	if (source instanceof Set) {
 		const output = new (source.constructor as SetConstructor)() as unknown as T & T extends Set<infer K> ? Set<K> : never;
 		for (const value of source.values()) output.add(deepClone(value));
-		return output as unknown as T;
+		return output as unknown as R;
 	}
-	return source;
+	return source as R;
 }

--- a/test/deepClone.ts
+++ b/test/deepClone.ts
@@ -104,3 +104,13 @@ ava('deepClone(set)', (test): void => {
 	test.true(cloned.has('Hello'));
 	test.true(cloned.has('World'));
 });
+
+ava('deepClone(readonly-array-to-mutable)', (test): void => {
+	test.plan(2);
+	const source: readonly number[] = [1, 2, 3];
+	// Mutate the type of the clone to a regular array of numbers
+	const clone = deepClone<readonly number[], number[]>(source);
+
+	test.not(source, clone);
+	test.deepEqual(clone, source);
+});


### PR DESCRIPTION
I came across this while doing some work on Skyra, in particular on the branch where we updated to @kyranet's eslint-config-bamboo v4.0. Namely we are retrieving some data from the settings:
```ts
const guildStickyRoles = this.guild.settings.get(GuildSettings.StickyRoles);
```

The type of `guildStickyRoles` is `readonly StickyRole[]`. 

A bit later we clone that array:
```ts
const clone = deepClone(stickyRoles);
```

And as per the current code of `deepClone` the `clone` will also have the type of `readonly StickyRole[]`. However this is not desired as the clone should be mutable in this particular case. Previously in Skyra this was resolved with `as Mutable<StickyRole>`, however the ESLint [`@typescript-eslint/no-unnecessary-type-assertion`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.md) has been enabled by @kyranet in eslint-config-bamboo 4.0.0, which now throws an error for this pattern. To get around this issue it would be ideal if for the `deepClone` function it is, optionally, possible to define a custom return type. This is achieved with this PR.

For what it's worth I tried to also cover this in a test but sadly we can't do exact type assertions with Ava for as far as I can tell, not the way type asserting is done in repos like DefinitelyTyped anyway, so Ava cannot really check if the type of the cloned array is `number[]` I think. This might suffice though:
![image](https://user-images.githubusercontent.com/4019718/82571920-f44e1380-9b83-11ea-96ce-d889e89d736e.png)

If there are any suggestions on how to properly test this please let me know and I'll add the test assertion(s).



---
__Alternatives considered__
For now I have implemented this locally, however I think it would be a good addition to add this to @klasa/utils and since the change is non-breaking, entirely optional and TypeScript exclusive I hope you guys don't mind the change.

```ts
private customDeepClone<T, R extends T>(source: T) {
	return deepClone<T>(source) as R;
}
```

---

edit: force pushes are because I typo'd the commit message *sigh*